### PR TITLE
Implement qwik link command to add existing files to hosts-available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test-hosts

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ _default.........................(enabled): Default Mac OS X hosts - do not disa
 
 You should not disable or remove this host file as it is required by OS X during the boot process. Note that if you are not on OS X you will have to replace this default host file with the default host file from your OS. Do this using `qwik edit _default`.
 
-Now you can take your kludged-together host file and split it up into manageable pieces. Use `qwik add <host-file>` to add a new host file. Then run `qwik edit <host-file>` and paste in a section from your old file. To enable it, run `qwik enable <host-file>`.
+Now you can take your kludged-together host file and split it up into manageable pieces. Use `qwik add <host-file>` to add a new host file. Then run `qwik edit <host-file>` and paste in a section from your old file. Alternatively, use `qwik link <host-file-path>` to link to an existing partial hostfile. To enable it, run `qwik enable <host-file>`.
 
 One last thing: all we've done so far is define new host files. We haven't actually rewritten the master file at `/etc/hosts` yet. To do this, run `qwik refresh` (you may want to save a backup first, until you're satisfied that things are working as expected).
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Just in case you're using `qwik` as part of a script, it may be helpful to know 
 
 ## Development
 ### Running Tests
-Tests follow the [roundup](http://bmizerany.github.io/roundup/) shell unit testing framework. Install roundup using `brew install roundup`. Run all tests using `roundup tests/*`, or run a specific test using `roundup tests/refresh-test.sh`. *Important:* These tests must be run from within the root directory of the repository.
+Tests follow the [roundup](http://bmizerany.github.io/roundup/) shell unit testing framework. Install roundup using `brew install roundup`. Run all tests using `roundup test/*`, or run a specific test using `roundup test/refresh-test.sh`. *Important:* These tests must be run from within the root directory of the repository.
 
 ### Todo
 Qwik-hosts works well as-is, but there is always room in a project for improvement. I have the following features in mind for future development:

--- a/qwik
+++ b/qwik
@@ -55,7 +55,7 @@ initialize() {
 ##
 127.0.0.1       localhost
 255.255.255.255 broadcasthost
-::1             localhost 
+::1             localhost
 fe80::1%lo0     localhost
 EOM
 
@@ -74,6 +74,12 @@ create() {
   echo "# $file_name: (short description here)" > "$DIR_HOSTS_AVAILABLE/$file_name"
 }
 
+link() {
+  link_path=$1
+  file_name=$(basename $1)
+  ln -s "$link_path" "$DIR_HOSTS_AVAILABLE/$file_name"
+}
+
 add_hosts() {
   for file_name in "$@"; do
     if [ -f "$DIR_HOSTS_AVAILABLE/$file_name" ]; then
@@ -81,6 +87,21 @@ add_hosts() {
       exit $ERR_BAD_USAGE
     fi
     create $file_name
+  done
+}
+
+link_hosts() {
+  for file_name in "$@"; do
+    if [ -f "$DIR_HOSTS_AVAILABLE/$file_name" ]; then
+      echo "Error: $file_name already exists. Use 'qwik edit $file_name'."
+      exit $ERR_BAD_USAGE
+    fi
+    if [[ "${file_name:0:1}" = "/" && -f "$file_name" ]]; then
+      link $file_name
+    else
+      echo "Error: '$file_name' does not exist or is not an absolute path."
+      exit $ERR_BAD_USAGE
+    fi
   done
 }
 
@@ -229,6 +250,13 @@ case $CMD in
     fi
     add_hosts "${@:2}"
     ;;
+  link)
+    if [ $# -lt 2 ]; then
+      echo "Usage: $EXECUTABLE $CMD <host-file> [<host-file>...]"
+      exit $ERR_BAD_USAGE
+    fi
+    link_hosts "${@:2}"
+    ;;
   fadd|fast-add)
     if [ $# -ne 2 ]; then
       echo "Usage: $EXECUTABLE $CMD <host-file>"
@@ -286,7 +314,7 @@ case $CMD in
     show_help
     ;;
   *)
-    echo "$EXECUTABLE: unrecognized command '$CMD'" 
+    echo "$EXECUTABLE: unrecognized command '$CMD'"
     echo "Try '$EXECUTABLE --help' for options."
     ;;
 esac

--- a/test/file-ops-test.sh
+++ b/test/file-ops-test.sh
@@ -28,6 +28,25 @@ it_creates_new_host() {
   [ 2 -eq $status ]
 }
 
+it_links_host_files() {
+  # Try to link nonexistent hostfile
+  status=$(set +e ; ./qwik link /tmp/tmp-hostfile >/dev/null ; echo $?)
+  [ 2 -eq $status ]
+
+  # Now, create the file and try again
+  echo "# host1" > /tmp/tmp-hostfile
+  ./qwik link host1
+  [ -f "./test-hosts/hosts-available/tmp-hostfile" ]
+  grep -q '# host1' "./test-hosts/hosts-available/tmp-hostfile"
+
+  # Can't link a host if it already exists
+  status=$(set +e ; ./qwik link /tmp/tmp-hostfile >/dev/null ; echo $?)
+  [ 2 -eq $status ]
+
+  # Cleanup
+  rm /tmp/tmp-hostfile
+}
+
 it_creates_new_host_if_dne() {
   # Edit a host that does not exist
   ./qwik edit host1 <<< :wq


### PR DESCRIPTION
Since I manage my host files in git repo, I find it useful to symlink to them from qwik. This PR adds a new command to create a symlink from `hosts-available` to a given file. Once the symlink exists, other commands like `qwik edit` will operate on the source file.

```sh
# creates ~/.qwik/hosts-available/lab-hosts -> /Users/<user>/my-env/hosts/lab-hosts
$ qwik link ~/my-env/hosts/lab-hosts
```

I wasn't able to get the tests to complete though, even on master -- it just hangs at "Filesystem operations on host modules". Could you try them on your system?